### PR TITLE
Hide cycle delay input when Manual output function is selected

### DIFF
--- a/app/views/brewbit/device_sessions/_output.html.erb
+++ b/app/views/brewbit/device_sessions/_output.html.erb
@@ -22,7 +22,7 @@
   </div>
 </div>
 
-<div class='form-group'>
+<div id="cycle_delay_<%= o.object.output_index %>" class='form-group'>
   <div class='col-sm-3 control-label'>
     <%= o.label :cycle_delay %>
   </div>
@@ -38,10 +38,11 @@
   $(document).ready(function() {
     $('#device_session_output_settings_attributes_<%= o.object.output_index %>_function_0, #device_session_output_settings_attributes_<%= o.object.output_index %>_function_1, #device_session_output_settings_attributes_<%= o.object.output_index %>_function_2').change(function(e){
       if ($(this).val() == <%= OutputSettings::FUNCTIONS[:manual] %>) {
-        $('#device_session_output_settings_attributes_<%= o.object.output_index %>_cycle_delay').hide();
+        $('#cycle_delay_<%= o.object.output_index %>').hide();
       }
       else {
-        $('#device_session_output_settings_attributes_<%= o.object.output_index %>_cycle_delay').show();
+        $('#cycle_delay_<%= o.object.output_index %>').show();
+        
       }
     });
   });

--- a/app/views/brewbit/device_sessions/_output.html.erb
+++ b/app/views/brewbit/device_sessions/_output.html.erb
@@ -34,4 +34,17 @@
   </div>
 </div>
 
+<script type="text/javascript">
+  $(document).ready(function() {
+    $('#device_session_output_settings_attributes_<%= o.object.output_index %>_function_0, #device_session_output_settings_attributes_<%= o.object.output_index %>_function_1, #device_session_output_settings_attributes_<%= o.object.output_index %>_function_2').change(function(e){
+      if ($(this).val() == <%= OutputSettings::FUNCTIONS[:manual] %>) {
+        $('#device_session_output_settings_attributes_<%= o.object.output_index %>_cycle_delay').hide();
+      }
+      else {
+        $('#device_session_output_settings_attributes_<%= o.object.output_index %>_cycle_delay').show();
+      }
+    });
+  });
+</script>
+
 <hr />


### PR DESCRIPTION
When the user selects Manual output function the cycle delay input field will be hidden. When cooling or heating are selected the cycle delay input field will be displayed.
