### PR TITLE
Better fix for showing most recent reading and set-point on the dashboard for Celcius users.

### DIFF
--- a/app/models/device_session.rb
+++ b/app/models/device_session.rb
@@ -103,7 +103,6 @@ class DeviceSession < ActiveRecord::Base
   
   def reports_since(last_update)
     reports = []
-    scale = device.try( :user ).try( :temperature_scale )
     File.open(readings_path, 'r') do |f|
       f.flock(File::LOCK_EX)
       f.extend(File::Reverse)
@@ -120,9 +119,6 @@ class DeviceSession < ActiveRecord::Base
             vals[i] = Float::NAN
           else
             vals[i] = vals[i].to_f
-            if scale == 'C'
-              vals[i] = fahrenheit_to_celsius( vals[i] )
-            end
           end
         end
 

--- a/app/views/brewbit/device_sessions/_device_session.html.erb
+++ b/app/views/brewbit/device_sessions/_device_session.html.erb
@@ -196,6 +196,12 @@
               last_reading = last_report[1];
               last_setpoint = last_report[2];
 
+              <% if @device.user.temperature_scale == 'C' -%>
+              // convert last reading and set-point to celsius
+              last_reading = ((last_reading - 32) / 1.8)
+              last_setpoint = ((last_setpoint - 32) / 1.8)
+              <% end %>
+
               $('#last-reading-<%= device_session.id %>').html(last_reading.toFixed(1));
               $('#last-setpoint-<%= device_session.id %>').html(last_setpoint.toFixed(1));
 


### PR DESCRIPTION
The previous attempt (#4) caused the AJAXed in most recent value to be double converted to Celcius when updating the graph.

This time,  readings are passed in F over the wire and only convert to C in js.  This is consistent with how the clientside JS receives all other readings when preparing the graph on a page load.
