### PR TITLE
Temperature units and rounding fixes.

### DIFF
--- a/app/models/session_event.rb
+++ b/app/models/session_event.rb
@@ -57,7 +57,9 @@ class SessionEvent < ActiveRecord::Base
         "'Step #{field_value.to_i + 1}'"
       end
     when 'static_setpoint'
-      field_value.round(1)
+      scale = device_session.try( :device ).try( :user ).try( :temperature_scale )
+      label = (scale || "").empty? ? "" : "°#{scale}"
+      "#{field_value.round(1)}#{label}"
     else
       field_value
     end

--- a/app/views/brewbit/device_sessions/_form.html.erb
+++ b/app/views/brewbit/device_sessions/_form.html.erb
@@ -87,7 +87,7 @@
       </div>
       <div class='col-sm-9'>
         <div class="input-group">
-          <%= f.text_field :static_setpoint, class: 'form-control', value: @device_session.static_setpoint %>
+          <%= f.text_field :static_setpoint, class: 'form-control', value: @device_session.static_setpoint.round(1) %>
           <span class="input-group-addon">&deg;<%= brewbit_current_user.temperature_scale %></span>
         </div>
       </div>


### PR DESCRIPTION
Show temp units on session event hovercards.
  -- previously hovercards would read 'Update session (static setpoint = 20)'
  -- with this change, temp units are appended, eg. 'Update session (static setpoint = 20°C)'
Round static setpoint to nearest 0.1deg in session edit form.
  -- previously a C setpoint (eg. 19C) would be saved (after a fahrenheit conversion), then if the session was re-edited the C setpoint would show some rounding errors (eg. 19.0000004C)
  -- with this change it is rounded back to the nearest 0.1 degrees (C or F).  This does affect what gets stored to the DB but I think the error is tiny.
