### PR TITLE
Make DEVICE_GATEWAY_API_URL configurable as an env

### DIFF
--- a/app/services/device_service.rb
+++ b/app/services/device_service.rb
@@ -1,7 +1,7 @@
 require 'json'
 
 class DeviceService
-  DEVICE_GATEWAY_API_URL = 'http://localhost:10080'
+  DEVICE_GATEWAY_API_URL = ENV['BREWBIT_DEVICE_GATEWAY_API_URL'] || 'http://localhost:10080'
 
   def self.send_activation_notification(device)
     options = {


### PR DESCRIPTION
This is part of a project to Dockerize the web interface. With Docker Compose, the brewbit-device-server won't be on localhost, so there needs to be an option to configure the path.